### PR TITLE
:pencil2: Fix typo in the getting started doc

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -52,7 +52,7 @@ const newAnimals = {
   ...animals,
   weasels: {
     ...animals.weasels,
-    otter: {
+    lutraLutra: {
       ...animals.weasels.lutraLutra,
       name: 'Lutra lutra',
     },


### PR DESCRIPTION
### Prerequisites
- [x] I have read the [Contributing guidelines](https://github.com/Zenika/immutadot/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Code of conduct](https://github.com/Zenika/immutadot/blob/master/.github/CODE_OF_CONDUCT.md) and I agree with it

### Description
Fixing a typo in the getting started doc.

Before
```
 const newAnimals = {
  ...animals,
  weasels: {
    ...animals.weasels,
    lutraLutra: {
      ...animals.weasels.otter,
      name: 'Lutra lutra',
    },
  },
}

```

After
```
const newAnimals = {
  ...animals,
  weasels: {
    ...animals.weasels,
    otter: {
      ...animals.weasels.lutraLutra,
      name: 'Lutra lutra',
    },
  },
}
```
