### PR TITLE
:bug: Do not crash when immutadot imported and array methods are missing

### DIFF
--- a/packages/immutadot/src/array/applyArrayMethod.js
+++ b/packages/immutadot/src/array/applyArrayMethod.js
@@ -20,7 +20,14 @@ const applyMethodReturnThis = (method, thisArg, args) => {
   return thisArg
 }
 
-const applyArrayMethod = (method, { arity = method.length, fixedArity = false, mutating = true } = {}) => {
+const applyArrayMethod = (name, { method = Array.prototype[name], arity = method && method.length, fixedArity = false, mutating = true } = {}) => {
+  if (!method) {
+    const error = `immutadot: Array.prototype.${name} is not available`
+    // eslint-disable-next-line no-console
+    console.warn(error)
+    return () => { throw TypeError(error) }
+  }
+
   const getArray = mutating ? toArrayCopy : toArray
   const applyMethod = mutating ? applyMethodReturnThis : applyMethodReturnResult
   return apply(

--- a/packages/immutadot/src/array/applyArrayMethod.spec.js
+++ b/packages/immutadot/src/array/applyArrayMethod.spec.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+/* eslint-disable no-console */
+import { applyArrayMethod } from './applyArrayMethod'
+
+describe('applyArrayMethod', () => {
+
+  it('should console.warn if method does not exist', () => {
+    const warn = jest.spyOn(console, 'warn')
+
+    applyArrayMethod('doesNotExist')
+
+    expect(warn).toBeCalledWith('immutadot: Array.prototype.doesNotExist is not available')
+
+    warn.mockRestore()
+  })
+
+  it('should throw a TypeError if called and method does not exist', () => {
+    const doesNotExist = applyArrayMethod('doesNotExist')
+
+    expect(doesNotExist).toThrowError(TypeError('immutadot: Array.prototype.doesNotExist is not available'))
+  })
+})

--- a/packages/immutadot/src/array/concat.js
+++ b/packages/immutadot/src/array/concat.js
@@ -13,6 +13,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.concat|Array.prototype.concat} for more information.
  * @since 0.2.0
  */
-const concat = applyArrayMethod(Array.prototype.concat, { mutating: false })
+const concat = applyArrayMethod('concat', { mutating: false })
 
 export { concat }

--- a/packages/immutadot/src/array/copyWithin.js
+++ b/packages/immutadot/src/array/copyWithin.js
@@ -14,7 +14,7 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.copyWithin|Array.prototype.copyWithin} for more information.
  * @since 2.0.0
  */
-const copyWithin = applyArrayMethod(Array.prototype.copyWithin, {
+const copyWithin = applyArrayMethod('copyWithin', {
   arity: 1,
   mutating: true,
 })

--- a/packages/immutadot/src/array/fill.js
+++ b/packages/immutadot/src/array/fill.js
@@ -14,6 +14,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.fill|Array.prototype.fill} for more information.
  * @since 0.3.0
  */
-const fill = applyArrayMethod(Array.prototype.fill)
+const fill = applyArrayMethod('fill')
 
 export { fill }

--- a/packages/immutadot/src/array/filter.js
+++ b/packages/immutadot/src/array/filter.js
@@ -12,6 +12,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.filter|Array.prototype.filter} for more information.
  * @since 1.0.0
  */
-const filter = applyArrayMethod(Array.prototype.filter, { mutating: false })
+const filter = applyArrayMethod('filter', { mutating: false })
 
 export { filter }

--- a/packages/immutadot/src/array/flat.js
+++ b/packages/immutadot/src/array/flat.js
@@ -11,6 +11,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.flat|Array.prototype.flat} for more information.
  * @since 2.0.0
  */
-const flat = applyArrayMethod(Array.prototype.flat, { mutating: false })
+const flat = applyArrayMethod('flat', { mutating: false })
 
 export { flat }

--- a/packages/immutadot/src/array/flatMap.js
+++ b/packages/immutadot/src/array/flatMap.js
@@ -11,6 +11,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.flatMap|Array.prototype.flatMap} for more information.
  * @since 2.0.0
  */
-const flatMap = applyArrayMethod(Array.prototype.flatMap, { mutating: false })
+const flatMap = applyArrayMethod('flatMap', { mutating: false })
 
 export { flatMap }

--- a/packages/immutadot/src/array/map.js
+++ b/packages/immutadot/src/array/map.js
@@ -12,6 +12,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.map|Array.prototype.map} for more information.
  * @since 1.0.0
  */
-const map = applyArrayMethod(Array.prototype.map, { mutating: false })
+const map = applyArrayMethod('map', { mutating: false })
 
 export { map }

--- a/packages/immutadot/src/array/pop.js
+++ b/packages/immutadot/src/array/pop.js
@@ -11,6 +11,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.pop|Array.prototype.pop} for more information.
  * @since 1.0.0
  */
-const pop = applyArrayMethod(Array.prototype.pop, { fixedArity: true })
+const pop = applyArrayMethod('pop', { fixedArity: true })
 
 export { pop }

--- a/packages/immutadot/src/array/push.js
+++ b/packages/immutadot/src/array/push.js
@@ -15,6 +15,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.push|Array.prototype.push} for more information.
  * @since 0.1.7
  */
-const push = applyArrayMethod(Array.prototype.push)
+const push = applyArrayMethod('push')
 
 export { push }

--- a/packages/immutadot/src/array/reverse.js
+++ b/packages/immutadot/src/array/reverse.js
@@ -11,6 +11,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.reverse|Array.prototype.reverse} for more information..
  * @since 0.3.0
  */
-const reverse = applyArrayMethod(Array.prototype.reverse, { fixedArity: true })
+const reverse = applyArrayMethod('reverse', { fixedArity: true })
 
 export { reverse }

--- a/packages/immutadot/src/array/shift.js
+++ b/packages/immutadot/src/array/shift.js
@@ -11,6 +11,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.shift|Array.prototype.shift} for more information.
  * @since 1.0.0
  */
-const shift = applyArrayMethod(Array.prototype.shift, { fixedArity: true })
+const shift = applyArrayMethod('shift', { fixedArity: true })
 
 export { shift }

--- a/packages/immutadot/src/array/slice.js
+++ b/packages/immutadot/src/array/slice.js
@@ -14,7 +14,7 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.slice|Array.prototype.slice} for more information.
  * @since 0.3.0
  */
-const slice = applyArrayMethod(Array.prototype.slice, {
+const slice = applyArrayMethod('slice', {
   arity: 0,
   mutating: false,
 })

--- a/packages/immutadot/src/array/sort.js
+++ b/packages/immutadot/src/array/sort.js
@@ -13,6 +13,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.sort|Array.prototype.sort} for more information.
  * @since 1.0.0
  */
-const sort = applyArrayMethod(Array.prototype.sort, { arity: 0 })
+const sort = applyArrayMethod('sort', { arity: 0 })
 
 export { sort }

--- a/packages/immutadot/src/array/splice.js
+++ b/packages/immutadot/src/array/splice.js
@@ -14,6 +14,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.splice|Array.prototype.splice} for more information.
  * @since 0.2.0
  */
-const splice = applyArrayMethod(Array.prototype.splice)
+const splice = applyArrayMethod('splice')
 
 export { splice }

--- a/packages/immutadot/src/array/unshift.js
+++ b/packages/immutadot/src/array/unshift.js
@@ -15,6 +15,6 @@ import { applyArrayMethod } from './applyArrayMethod'
  * @see {@link https://mdn.io/Array.prototype.unshift|Array.prototype.unshift} for more information.
  * @since 0.1.7
  */
-const unshift = applyArrayMethod(Array.prototype.unshift)
+const unshift = applyArrayMethod('unshift')
 
 export { unshift }


### PR DESCRIPTION
### Description
Do not crash when immutadot is imported and some Array methods are missing.
Warns when immutadot is imported, and crashes if called.
Advantage of this is we don't decide to use a polyfill, this is the choice of our users.

**Issue :**
Simply requiring immutadot@v2.0.0-alpha.1 on node <11 crashes because of flat and flatMap not being implemented on Array.prototype.
https://runkit.com/embed/ruqc5msck20u
